### PR TITLE
ci(github): changes github checks config

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,5 +1,5 @@
 name: Checks
-on: [push, pull_request]
+on: push
 
 jobs:
   lint:
@@ -21,7 +21,7 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-          
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
## Description

This PR changes when github checks run. From now on, it only runs on `push` and not on `[push, pull_request]`