### PR TITLE
feat: :lock: Added default security headers

### DIFF
--- a/src/templates/next/next.config.js
+++ b/src/templates/next/next.config.js
@@ -1,4 +1,29 @@
 module.exports = {
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'X-XSS-Protection',
+            value: '1; mode=block',
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin',
+          },
+        ],
+      }
+    ]
+  },
   webpack(config) {
     config.module.rules.push({
       test: /\.svg$/,


### PR DESCRIPTION
I makes sense to have these sensible defaults.
For me it also makes it easier to add/find the headers config.
None of these headers are breaking and should not have any impact in sane apps.
CSP not added.
